### PR TITLE
Fix constraint violation in MySQL on the import.

### DIFF
--- a/app/Imports/CountriesImport.php
+++ b/app/Imports/CountriesImport.php
@@ -26,8 +26,8 @@ class CountriesImport implements ToCollection
             ], [
                 'name' => $country[7],
                 'code' => $country[2],
-                'latitude' => $country[8],
-                'longitude' => $country[9],
+                'latitude' => $country[8] ?? 0,
+                'longitude' => $country[9] ?? 0,
             ]);
         });
     }


### PR DESCRIPTION
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'latitude' cannot be null

(SQL: update `countries` set `latitude` = ?, `longitude` = ?, `countries`.`updated_at` = 2020-11-06 23:51:53 where `id` = 94)

- Added 0 as default in the import.