### PR TITLE
Implement 'php artisan serve' command.

### DIFF
--- a/app/Console/Commands/ServeCommand.php
+++ b/app/Console/Commands/ServeCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\ProcessUtils;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Process\PhpExecutableFinder;
+
+/**
+ * Class ServeCommand
+ *
+ * @see https://github.com/flipboxstudio/lumen-generator/blob/develop/src/LumenGenerator/Console/ServeCommand.php
+ * @package App\Console\Commands
+ */
+class ServeCommand extends Command
+{
+    /**
+     * The console commmand name.
+     *
+     * @var string
+     */
+    protected $name = 'serve';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Serve the application on the PHP development server';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function handle()
+    {
+        chdir($this->laravel->basePath('public'));
+
+        $this->line("<info>Laravel development server started:</info>  <http://{$this->host()}:{$this->port()}>");
+
+        passthru($this->serverCommand());
+    }
+
+    /**
+     * Get the full server command.
+     *
+     * @return string
+     */
+    protected function serverCommand()
+    {
+        $base = base_path();
+        if (file_exists("$base/server.php")) {
+            $command = '%s -S %s:%s %s/server.php';
+        } else {
+            $command = '%s -S %s:%s -t %s/public/';
+        }
+
+        return sprintf($command,
+            ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
+            $this->host(),
+            $this->port(),
+            ProcessUtils::escapeArgument($base)
+        );
+    }
+
+    /**
+     * Get the host for the command.
+     *
+     * @return string
+     */
+    protected function host()
+    {
+        return $this->input->getOption('host');
+    }
+
+    /**
+     * Get the port for the command.
+     *
+     * @return string
+     */
+    protected function port()
+    {
+        return $this->input->getOption('port');
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
+            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+        ];
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\CountriesImportCommand;
+use App\Console\Commands\ServeCommand;
 use App\Console\Commands\TimeSeriesFetchCommand;
 use App\Console\Commands\TimeSeriesImportCommand;
 use Illuminate\Console\Scheduling\Schedule;
@@ -19,6 +20,7 @@ class Kernel extends ConsoleKernel
         TimeSeriesFetchCommand::class,
         CountriesImportCommand::class,
         TimeSeriesImportCommand::class,
+        ServeCommand::class,
     ];
 
     /**


### PR DESCRIPTION
With this command is implemented the `php artisan serve` command.
This will be easier to run the server while working on the API. 

Note: That the original source source is located [here](https://github.com/flipboxstudio/lumen-generator/blob/develop/src/LumenGenerator/Console/ServeCommand.php) Als dat why is added a class doc with an `@see` attribute that is linked to the source. 
